### PR TITLE
Add inverse of sqrt

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -11,3 +11,9 @@ inverse
 ```@docs
 InverseFunctions.test_inverse
 ```
+
+## Additional functions
+
+```@docs
+InverseFunctions.square
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,4 +8,4 @@ This package defines the function [`inverse`](@ref). `inverse(f)` returns the in
 
 `inverse` supports mapped/broadcasted functions (via `Base.Fix1`) and (on Julia >=v1.6) function composition.
 
-Implementations of `inverse(f)` for `identity`, `inv`, `adjoint` and `transpose` as well as for `exp`, `log`, `exp2`, `log2`, `exp10`, `log10`, `expm1` and `log1p` are included.
+Implementations of `inverse(f)` for `identity`, `inv`, `adjoint` and `transpose` as well as for `exp`, `log`, `exp2`, `log2`, `exp10`, `log10`, `expm1`, `log1p` and `sqrt` are included.

--- a/src/InverseFunctions.jl
+++ b/src/InverseFunctions.jl
@@ -8,6 +8,7 @@ module InverseFunctions
 
 using Test
 
+include("functions.jl")
 include("inverse.jl")
 include("test.jl")
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,0 +1,8 @@
+# This file is a part of InverseFunctions.jl, licensed under the MIT License (MIT).
+
+"""
+    square(x)
+
+Inverse of `sqrt(x)`.
+"""
+square(x) = x^2

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -3,6 +3,6 @@
 """
     square(x)
 
-Inverse of `sqrt(x)`.
+Inverse of `sqrt(x)` for non-negative `x`.
 """
 square(x) = x^2

--- a/src/inverse.jl
+++ b/src/inverse.jl
@@ -76,3 +76,6 @@ inverse(::typeof(log10)) = exp10
 
 inverse(::typeof(expm1)) = log1p
 inverse(::typeof(log1p)) = expm1
+
+inverse(::typeof(sqrt)) = square
+inverse(::typeof(square)) = sqrt

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ import InverseFunctions
 import Documenter
 
 Test.@testset "Package InverseFunctions" begin
+    include("test_functions.jl")
     include("test_inverse.jl")
 
     # doctests

--- a/test/test_functions.jl
+++ b/test/test_functions.jl
@@ -1,0 +1,11 @@
+# This file is a part of InverseFunctions.jl, licensed under the MIT License (MIT).
+
+using Test
+using InverseFunctions
+
+
+@testset "square" begin
+    for x in (-0.72, 0.73, randn(3, 3))
+        @test InverseFunctions.square(x) ≈ x * x
+    end
+end

--- a/test/test_inverse.jl
+++ b/test/test_inverse.jl
@@ -23,7 +23,7 @@ InverseFunctions.inverse(f) = Bar(inv(f.A))
     InverseFunctions.test_inverse(inverse, log, compare = ===)
 
     x = rand()
-    for f in (foo, inv_foo, exp, log, exp2, log2, exp10, log10, expm1, log1p)
+    for f in (foo, inv_foo, exp, log, exp2, log2, exp10, log10, expm1, log1p, sqrt)
         InverseFunctions.test_inverse(f, x)
     end
 


### PR DESCRIPTION
We should define the inverse of `sqrt`.

Use case: GPLikelihoods.jl will need this.