### PR TITLE
Inversion macro

### DIFF
--- a/src/inverse.jl
+++ b/src/inverse.jl
@@ -80,7 +80,7 @@ end
 
 inverse(mapped_f::Base.Fix1{<:Union{typeof(map),typeof(broadcast)}}) = Base.Fix1(mapped_f.f, inverse(mapped_f.x))
 
-# Idempotent functions
+# Involutions
 inverse(::typeof(identity)) = identity
 inverse(::typeof(inv)) = inv
 inverse(::typeof(adjoint)) = adjoint

--- a/src/inverse.jl
+++ b/src/inverse.jl
@@ -80,22 +80,20 @@ end
 
 inverse(mapped_f::Base.Fix1{<:Union{typeof(map),typeof(broadcast)}}) = Base.Fix1(mapped_f.f, inverse(mapped_f.x))
 
+# Idempotent functions
 inverse(::typeof(identity)) = identity
 inverse(::typeof(inv)) = inv
 inverse(::typeof(adjoint)) = adjoint
 inverse(::typeof(transpose)) = transpose
 
-inverse(::typeof(exp)) = log
-inverse(::typeof(log)) = exp
+# Pairs of inverses
+inverse_pairs = (exp => log,
+                 exp2 => log2,
+                 exp10 => log10,
+                 expm1 => log1p,
+                 square => sqrt)
+for op_pair in inverse_pairs
+    @eval inverse(::typeof($op_pair.first)) = $op_pair.second
+    @eval inverse(::typeof($op_pair.second)) = $op_pair.first
+end
 
-inverse(::typeof(exp2)) = log2
-inverse(::typeof(log2)) = exp2
-
-inverse(::typeof(exp10)) = log10
-inverse(::typeof(log10)) = exp10
-
-inverse(::typeof(expm1)) = log1p
-inverse(::typeof(log1p)) = expm1
-
-inverse(::typeof(sqrt)) = square
-inverse(::typeof(square)) = sqrt


### PR DESCRIPTION
I was experimenting with this package (see #15) and am also in the process of trying to learn Julia, any feedback on this code would be helpful, and maybe it is preferable idiom for this package.

Defining all the inverses through the repeated typing of `inverse(::typeof(func)) = inv_func` and `inverse(::typeof(inv_func)) = func` seemed strange, so I replaced this with what was inspired by the code generation section of the [metaprogramming docs](https://docs.julialang.org/en/v1/manual/metaprogramming/).  Since the inverse of every inverse function is the function itself, you need only specify the (function, inverse function) pairs, and that should be enough to implement all the `inverse` methods.