### PR TITLE
add more inverses

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InverseFunctions"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -10,3 +10,15 @@ function square(x::Real)
     x < zero(x) && throw(DomainError(x, "`square` is defined as the inverse of `sqrt` and can only be evaluated for non-negative values"))
     return x^2
 end
+
+
+invpow2(x::Real, p::Integer) = sign(x) * abs(x)^inv(p)
+invpow2(x::Real, p::Real) = x ≥ zero(x) ? x^inv(p) : throw(DomainError(x, "inverse for x^$p is not defined at $x"))
+invpow2(x, p) = x^inv(p)
+
+invpow1(b, x) = log(abs(b), abs(x))
+
+invlog1(b::Real, x::Real) = b ≥ zero(b) && x ≥ zero(x) ? b^x : throw(DomainError(x, "inverse for log($b, x) is not defined at $x"))
+invlog1(b, x) = b^x
+
+invlog2(b, x) = x^inv(b)

--- a/src/inverse.jl
+++ b/src/inverse.jl
@@ -84,9 +84,25 @@ inverse(::typeof(identity)) = identity
 inverse(::typeof(inv)) = inv
 inverse(::typeof(adjoint)) = adjoint
 inverse(::typeof(transpose)) = transpose
+inverse(::typeof(conj)) = conj
 
+inverse(::typeof(!)) = !
 inverse(::typeof(+)) = +
 inverse(::typeof(-)) = -
+
+inverse(f::Base.Fix1{typeof(+)}) = Base.Fix2(-, f.x)
+inverse(f::Base.Fix2{typeof(+)}) = Base.Fix2(-, f.x)
+inverse(f::Base.Fix1{typeof(-)}) = Base.Fix1(-, f.x)
+inverse(f::Base.Fix2{typeof(-)}) = Base.Fix1(+, f.x)
+inverse(f::Base.Fix1{typeof(*)}) = iszero(f.x) ? throw(DomainError(f.x, "Cannot invert multiplication by zero")) : Base.Fix1(\, f.x)
+inverse(f::Base.Fix2{typeof(*)}) = iszero(f.x) ? throw(DomainError(f.x, "Cannot invert multiplication by zero")) : Base.Fix2(/, f.x)
+inverse(f::Base.Fix1{typeof(/)}) = Base.Fix2(\, f.x)
+inverse(f::Base.Fix2{typeof(/)}) = Base.Fix2(*, f.x)
+inverse(f::Base.Fix1{typeof(\)}) = Base.Fix1(*, f.x)
+inverse(f::Base.Fix2{typeof(\)}) = Base.Fix1(/, f.x)
+
+inverse(::typeof(deg2rad)) = rad2deg
+inverse(::typeof(rad2deg)) = deg2rad
 
 inverse(::typeof(exp)) = log
 inverse(::typeof(log)) = exp
@@ -102,3 +118,13 @@ inverse(::typeof(log1p)) = expm1
 
 inverse(::typeof(sqrt)) = square
 inverse(::typeof(square)) = sqrt
+
+inverse(::typeof(cbrt)) = Base.Fix2(^, 3)
+inverse(f::Base.Fix2{typeof(^)}) = iszero(f.x) ? throw(DomainError(f.x, "Cannot invert x^$(f.x)")) : Base.Fix2(invpow2, f.x)
+inverse(f::Base.Fix2{typeof(invpow2)}) = Base.Fix2(^, f.x)
+inverse(f::Base.Fix1{typeof(^)}) = Base.Fix1(invpow1, f.x)
+inverse(f::Base.Fix1{typeof(invpow1)}) = Base.Fix1(^, f.x)
+inverse(f::Base.Fix1{typeof(log)}) = Base.Fix1(invlog1, f.x)
+inverse(f::Base.Fix1{typeof(invlog1)}) = Base.Fix1(log, f.x)
+inverse(f::Base.Fix2{typeof(log)}) = Base.Fix2(invlog2, f.x)
+inverse(f::Base.Fix2{typeof(invlog2)}) = Base.Fix2(log, f.x)

--- a/test/test_inverse.jl
+++ b/test/test_inverse.jl
@@ -28,13 +28,43 @@ InverseFunctions.inverse(f::Bar) = Bar(inv(f.A))
 
     InverseFunctions.test_inverse(inverse, log, compare = ===)
 
+    InverseFunctions.test_inverse(!, false)
+
     x = rand()
-    for f in (foo, inv_foo, +, -, exp, log, exp2, log2, exp10, log10, expm1, log1p, sqrt)
+    for f in (
+            foo, inv_foo, log, log2, log10, log1p, sqrt,
+            Base.Fix2(^, rand()), Base.Fix2(^, rand([-10:-1; 1:10])), Base.Fix1(^, rand()), Base.Fix1(log, rand()), Base.Fix2(log, rand()),
+        )
         InverseFunctions.test_inverse(f, x)
     end
+    for f in (
+            +, -, exp, exp2, exp10, expm1, cbrt, deg2rad, rad2deg, conj,
+            Base.Fix1(+, rand()), Base.Fix2(+, rand()), Base.Fix1(-, rand()), Base.Fix2(-, rand()),
+            Base.Fix1(*, rand()), Base.Fix2(*, rand()), Base.Fix1(/, rand()), Base.Fix2(/, rand()), Base.Fix1(\, rand()), Base.Fix2(\, rand()),
+            Base.Fix2(^, rand(-11:2:11)),
+        )
+        InverseFunctions.test_inverse(f, x)
+        InverseFunctions.test_inverse(f, -x)
+    end
+    InverseFunctions.test_inverse(conj, 2 - 3im)
+
+    # ensure that inverses have domains compatible with original functions
+    @test_throws DomainError inverse(Base.Fix1(*, 0))
+    @test_throws DomainError inverse(Base.Fix2(^, 0))
+    @test_throws DomainError inverse(Base.Fix1(log, 2))(-5)
+    InverseFunctions.test_inverse(Base.Fix1(log, 2), -5 + 0im)
+    @test_throws DomainError inverse(Base.Fix2(^, 0.5))(-5)
+    InverseFunctions.test_inverse(Base.Fix2(^, 0.5), -5 + 0im)
 
     A = rand(5, 5)
-    for f in (identity, inv, adjoint, transpose)
+    for f in (
+            identity, inv, adjoint, transpose,
+            log, sqrt, +, -, exp,
+            Base.Fix1(+, rand(5, 5)), Base.Fix2(+, rand(5, 5)), Base.Fix1(-, rand(5, 5)), Base.Fix2(-, rand(5, 5)),
+            Base.Fix1(*, rand()), Base.Fix2(*, rand()), Base.Fix1(*, rand(5, 5)), Base.Fix2(*, rand(5, 5)),
+            Base.Fix2(/, rand()), Base.Fix1(/, rand(5, 5)), Base.Fix2(/, rand(5, 5)),
+            Base.Fix1(\, rand()), Base.Fix1(\, rand(5, 5)), Base.Fix2(\, rand(5, 5)),
+        )
         InverseFunctions.test_inverse(f, A)
     end
 


### PR DESCRIPTION
Following https://github.com/JuliaMath/InverseFunctions.jl/issues/12.

As I understand, all functions other than `^` and `log` are complete inverses on the whole available domain. Power and log inverses are implemented with separate functions to preserve proper domains, same approach as `sqrt <-> square`.