### PR TITLE
Fix tests on Julia v1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InverseFunctions"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test_inverse.jl
+++ b/test/test_inverse.jl
@@ -65,7 +65,10 @@ InverseFunctions.inverse(f::Bar) = Bar(inv(f.A))
             Base.Fix2(/, rand()), Base.Fix1(/, rand(5, 5)), Base.Fix2(/, rand(5, 5)),
             Base.Fix1(\, rand()), Base.Fix1(\, rand(5, 5)), Base.Fix2(\, rand(5, 5)),
         )
-        InverseFunctions.test_inverse(f, A)
+        if f != log || VERSION >= v"1.6"
+            # exp(log(A::AbstractMatrix)) ≈ A is broken on at least Julia v1.0
+            InverseFunctions.test_inverse(f, A)
+        end
     end
 
     X = rand(5)


### PR DESCRIPTION
`exp(log(A::AbstractMatrix)) ≈ A` is broken on v1.0