### PR TITLE
Increase type stability of NoInverse and FunctionWithInverse

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InverseFunctions"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/inverse.jl
+++ b/src/inverse.jl
@@ -62,10 +62,10 @@ An instance `NoInverse(f)` signifies that `inverse(f)` is not defined.
 """
 struct NoInverse{F}
     f::F
-    NoInverse{F}(f) where F = new{F}(f)
-    NoInverse(f) = new{Core.Typeof(f)}(f)
 end
 export NoInverse
+
+NoInverse(::Type{F}) where F = NoInverse{Type{F}}(F)
 
 (f::NoInverse)(x) = error("inverse of ", f.f, " is not defined")
 

--- a/src/inverse.jl
+++ b/src/inverse.jl
@@ -62,6 +62,8 @@ An instance `NoInverse(f)` signifies that `inverse(f)` is not defined.
 """
 struct NoInverse{F}
     f::F
+    NoInverse{F}(f) where F = new{F}(f)
+    NoInverse(f) = new{Core.Typeof(f)}(f)
 end
 export NoInverse
 

--- a/src/setinverse.jl
+++ b/src/setinverse.jl
@@ -11,6 +11,8 @@ Do not construct directly, use [`setinverse(f, invf)`](@ref) instead.
 struct FunctionWithInverse{F,InvF} <: Function
     f::F
     invf::InvF
+    FunctionWithInverse{F, InvF}(f, invf) where {F, InvF} = new{F, InvF}(f, invf)
+    FunctionWithInverse(f, invf) = new{Core.Typeof(f),Core.Typeof(invf)}(f, invf)
 end
 
 

--- a/src/setinverse.jl
+++ b/src/setinverse.jl
@@ -11,10 +11,10 @@ Do not construct directly, use [`setinverse(f, invf)`](@ref) instead.
 struct FunctionWithInverse{F,InvF} <: Function
     f::F
     invf::InvF
-    FunctionWithInverse{F, InvF}(f, invf) where {F, InvF} = new{F, InvF}(f, invf)
-    FunctionWithInverse(f, invf) = new{Core.Typeof(f),Core.Typeof(invf)}(f, invf)
 end
-
+FunctionWithInverse(::Type{F}, invf::InvF) where {F,InvF} = FunctionWithInverse{Type{F},InvF}(F,invf)
+FunctionWithInverse(f::F, ::Type{InvF}) where {F,InvF} = FunctionWithInverse{F,Type{InvF}}(f,InvF)
+FunctionWithInverse(::Type{F}, ::Type{InvF}) where {F,InvF} = FunctionWithInverse{Type{F},Type{InvF}}(F,InvF)
 
 (f::FunctionWithInverse)(x) = f.f(x)
 

--- a/test/test_inverse.jl
+++ b/test/test_inverse.jl
@@ -38,7 +38,6 @@ InverseFunctions.inverse(f::Bar) = Bar(inv(f.A))
 
     @test @inferred(inverse(Complex)) isa NoInverse{Type{Complex}}
     @test @inferred(NoInverse(Complex)) isa NoInverse{Type{Complex}}
-    @test @inferred(NoInverse{Type{Complex}}(Complex)) isa NoInverse{Type{Complex}}
 
     InverseFunctions.test_inverse(inverse, log, compare = ===)
 

--- a/test/test_inverse.jl
+++ b/test/test_inverse.jl
@@ -36,6 +36,10 @@ InverseFunctions.inverse(f::Bar) = Bar(inv(f.A))
         @test inverse(inverse(f)) == f
     end
 
+    @test @inferred(inverse(Complex)) isa NoInverse{Type{Complex}}
+    @test @inferred(NoInverse(Complex)) isa NoInverse{Type{Complex}}
+    @test @inferred(NoInverse{Type{Complex}}(Complex)) isa NoInverse{Type{Complex}}
+
     InverseFunctions.test_inverse(inverse, log, compare = ===)
 
     InverseFunctions.test_inverse(!, false)

--- a/test/test_setinverse.jl
+++ b/test/test_setinverse.jl
@@ -5,11 +5,15 @@ using InverseFunctions
 
 
 @testset "setinverse" begin
+    @test @inferred(setinverse(Complex, Real)) isa InverseFunctions.FunctionWithInverse{Type{Complex},Type{Real}}
+    @test @inferred(InverseFunctions.FunctionWithInverse(Complex, Real)) isa InverseFunctions.FunctionWithInverse{Type{Complex},Type{Real}}
+    @test @inferred(InverseFunctions.FunctionWithInverse{Type{Complex},Type{Real}}(Complex, Real)) isa InverseFunctions.FunctionWithInverse{Type{Complex},Type{Real}}
+    InverseFunctions.test_inverse(setinverse(Complex, Real), 4.2)
+
     @test @inferred(setinverse(sin, asin)) === InverseFunctions.FunctionWithInverse(sin, asin)
     @test @inferred(setinverse(sin, setinverse(asin, sqrt))) === InverseFunctions.FunctionWithInverse(sin, asin)
     @test @inferred(setinverse(setinverse(sin, sqrt), asin)) === InverseFunctions.FunctionWithInverse(sin, asin)
     @test @inferred(setinverse(setinverse(sin, asin), setinverse(asin, sqrt))) === InverseFunctions.FunctionWithInverse(sin, asin)
-
     InverseFunctions.test_inverse(setinverse(sin, asin), π/4)
     InverseFunctions.test_inverse(setinverse(asin, sin), 0.5)
 end

--- a/test/test_setinverse.jl
+++ b/test/test_setinverse.jl
@@ -7,8 +7,11 @@ using InverseFunctions
 @testset "setinverse" begin
     @test @inferred(setinverse(Complex, Real)) isa InverseFunctions.FunctionWithInverse{Type{Complex},Type{Real}}
     @test @inferred(InverseFunctions.FunctionWithInverse(Complex, Real)) isa InverseFunctions.FunctionWithInverse{Type{Complex},Type{Real}}
-    @test @inferred(InverseFunctions.FunctionWithInverse{Type{Complex},Type{Real}}(Complex, Real)) isa InverseFunctions.FunctionWithInverse{Type{Complex},Type{Real}}
+    @test @inferred(InverseFunctions.FunctionWithInverse(Real, identity)) isa InverseFunctions.FunctionWithInverse{Type{Real},typeof(identity)}
+    @test @inferred(InverseFunctions.FunctionWithInverse(identity, Real)) isa InverseFunctions.FunctionWithInverse{typeof(identity),Type{Real}}
     InverseFunctions.test_inverse(setinverse(Complex, Real), 4.2)
+    InverseFunctions.test_inverse(setinverse(Real, identity), 4.2)
+    InverseFunctions.test_inverse(setinverse(identity, Real), 4.2)
 
     @test @inferred(setinverse(sin, asin)) === InverseFunctions.FunctionWithInverse(sin, asin)
     @test @inferred(setinverse(sin, setinverse(asin, sqrt))) === InverseFunctions.FunctionWithInverse(sin, asin)


### PR DESCRIPTION
Make constructions like `setinverse(Complex, Real)` type-stable (this example would be for use cases in which the original input is restricted to be real, obviously).