### PR TITLE
Use codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       - uses: codecov/codecov-action@v4
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64'
         with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
   docs:
     name: Documentation


### PR DESCRIPTION
#44 broke codecov integration: https://github.com/JuliaMath/InverseFunctions.jl/actions/runs/8338775978/job/22819638714#step:8:31

